### PR TITLE
Add event dates to home page

### DIFF
--- a/src/components/home/hero/index.tsx
+++ b/src/components/home/hero/index.tsx
@@ -27,6 +27,7 @@ const Section: React.FC = () => (
     </div>
     <div className={styles.heroFooter}>
       <span className={styles.subtitle}>making memories</span>
+      <span className={styles.subsubtitle}>February 24 - 26</span>
       <img className={styles.banner} src={BANNER} />
       <img className={styles.lines} src={LINES} />
     </div>

--- a/src/components/home/hero/styles.module.scss
+++ b/src/components/home/hero/styles.module.scss
@@ -110,6 +110,19 @@
     }
   }
 
+  .subsubtitle {
+    line-height: 12px;
+    font-weight: 500;
+    font-size: 20px;
+    color: #ffffff;
+    margin-bottom: 15px;
+    margin-top: -10px;
+
+    @media screen and (max-width: 800px) {
+      font-size: 32px;
+    }
+  }
+
   .banner {
     width: 250px;
     margin-bottom: 25px;


### PR DESCRIPTION
It would be useful for site visitors to see the dates of the event. Historically this information was included somewhere on the home page for easy access:
- https://2021.hackillinois.org/
- https://2020.hackillinois.org/
- https://2019.hackillinois.org/
- etc...

Currently it's hard to tell when the hackathon is happening just by looking at the site. This PR adds those dates to the home page under the "making memories" title. 
 
## Description of changes
- Introduce a new `subsubtitle` class and use it to insert the dates of the event