### PR TITLE
fix: date & ferris wheel overlap

### DIFF
--- a/src/components/home/hero/styles.module.scss
+++ b/src/components/home/hero/styles.module.scss
@@ -114,6 +114,7 @@
   .topHeader {
     position: absolute;
     width: 100%;
+    z-index: 2;
   }
 
   .ferrisWheelLarge {


### PR DESCRIPTION
## Motivation

On my 15.6" laptop screen, there is an overlap happening with the dates and ferris wheel.

**Note:** It looks fine on my monitor (idk the size off the top of my head)

## Solution

Increases the `z-index` of the `topHeader` class. This should not break anything on other screen sizes