### PR TITLE
Change bottom for ferris wheel

### DIFF
--- a/src/components/home/hero/styles.module.scss
+++ b/src/components/home/hero/styles.module.scss
@@ -129,7 +129,7 @@
     position: absolute;
     left: 50%;
     transform: translate(-50%, 8.8%);
-    bottom: -40px;
+    bottom: 0px;
     height: 60%;
   }
 


### PR DESCRIPTION
The ferris wheel is too low on Google chrome. This PR moves it slightly up.