### PR TITLE
Update event description Date

### DIFF
--- a/modules/EventsData.ts
+++ b/modules/EventsData.ts
@@ -2,6 +2,6 @@ export const event_description = {
     description_1:
         "HackIllinois is University of Illinois at Urbana-Champaign's premiere collegiate hackathon.",
     description_2:
-        "Join us in-person from February 23th to February 25th at the Siebel Center for Computer Science! Participants can work individually or in teams to submit projects to a specific track for a chance to win prizes.",
+        "Join us in-person from February 23rd to February 25th at the Siebel Center for Computer Science! Participants can work individually or in teams to submit projects to a specific track for a chance to win prizes.",
     description_3: "Adventure awaits!"
 };


### PR DESCRIPTION
In en_US, it is more common to refer to the event date as `February 23rd` rather than `February 23th`.