### PR TITLE
Add logic fix to correctly display Pro applicants

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -139,7 +139,7 @@ const Some: React.FC = () => {
             return false;
         }
 
-        if (registration?.isProApplicant && !RSVP?.admittedPro && RSVP?.status) {
+        if (registration?.isProApplicant && !RSVP?.admittedPro && RSVP?.status === "ACCEPTED") {
             // Applicant was PRO but got deferred and accepted to GENERAL
             return false;
         }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -10,7 +10,7 @@ import MobileWindowPane from "@/public/profile/mobile-window-pane.svg";
 
 import { Bookshelf } from "@/components/Profile/Bookshelf";
 import { ModalOverlay, useModal } from "@/components/Profile/modal";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
     authenticate,
     getRSVP,
@@ -133,7 +133,7 @@ const Some: React.FC = () => {
         })();
     }, [RSVP]);
 
-    const getIsPro = () => {
+    const getIsPro = useCallback(() => {
         if (!registration?.isProApplicant) {
             // The applicant did not register as PRO
             return false;
@@ -146,7 +146,7 @@ const Some: React.FC = () => {
 
         // Applicant registered as a pro, but can be accepted or not accepted
         return true;
-    }
+    }, [registration, RSVP]);
 
     return (
         <section className={styles.dashboard}>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -125,8 +125,6 @@ const Some: React.FC = () => {
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
-        if (RSVP?.admittedPro) return;
-
         (async () => {
             setLoading(true);
             const registration = await getRegistration();
@@ -134,6 +132,21 @@ const Some: React.FC = () => {
             setLoading(false);
         })();
     }, [RSVP]);
+
+    const getIsPro = () => {
+        if (!registration?.isProApplicant) {
+            // The applicant did not register as PRO
+            return false;
+        }
+
+        if (registration?.isProApplicant && !RSVP?.admittedPro && RSVP?.status) {
+            // Applicant was PRO but got deferred and accepted to GENERAL
+            return false;
+        }
+
+        // Applicant registered as a pro, but can be accepted or not accepted
+        return true;
+    }
 
     return (
         <section className={styles.dashboard}>
@@ -240,7 +253,7 @@ const Some: React.FC = () => {
                 openModal={openModal}
                 isModalOpen={isModalOpen}
                 name={user?.name}
-                admittedPro={RSVP?.admittedPro}
+                isPro={getIsPro()}
                 status={RSVP?.status}
                 response={RSVP?.response}
                 onActionClick={onActionClick}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -52,9 +52,12 @@ const Some: React.FC = () => {
     const [user, setUser] = useState<UserType | null>(null);
     const [RSVP, setRSVP] = useState<RSVPType | null>(null);
     const [profile, setProfileState] = useState<ProfileType | null>(null);
+
+    // Registration data is non-null only if the applicant wasn't accepted as PRO
     const [registration, setRegistration] = useState<RegistrationType | null>(
         null
     );
+
     const [loading, setLoading] = useState<boolean>(true);
     const [showDeclineConfirmation, setShowDeclineConfirmation] =
         useState<boolean>(false);
@@ -125,6 +128,9 @@ const Some: React.FC = () => {
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
+        // No need to fetch registration data if the applicant is admitted as a Pro
+        if (RSVP?.admittedPro) return;
+
         (async () => {
             setLoading(true);
             const registration = await getRegistration();
@@ -139,7 +145,11 @@ const Some: React.FC = () => {
             return false;
         }
 
-        if (registration?.isProApplicant && !RSVP?.admittedPro && RSVP?.status === "ACCEPTED") {
+        if (
+            registration?.isProApplicant &&
+            !RSVP?.admittedPro &&
+            RSVP?.status === "ACCEPTED"
+        ) {
             // Applicant was PRO but got deferred and accepted to GENERAL
             return false;
         }

--- a/components/Profile/Bookshelf.tsx
+++ b/components/Profile/Bookshelf.tsx
@@ -14,7 +14,7 @@ type Props = {
     isModalOpen: boolean;
     name?: string;
     status?: DecisionStatus;
-    admittedPro?: boolean;
+    isPro?: boolean;
     loading: boolean;
     onActionClick: () => void;
     response?: DecisionResponse;
@@ -26,7 +26,7 @@ export const Bookshelf = ({
     name = "",
     status = "TBD",
     loading = false,
-    admittedPro,
+    isPro,
     onActionClick,
     response
 }: Props) => {
@@ -34,7 +34,7 @@ export const Bookshelf = ({
         openModal();
     }
 
-    const type = admittedPro ? "HackKnight" : "General Admission";
+    const type = isPro ? "HackKnight" : "General Admission";
     const accepted = status === "ACCEPTED";
     const action = response === "PENDING" ? "View Status" : "Questions";
 


### PR DESCRIPTION
Before, we relied on RSVP?.isAdmittedPro to determine if an applicant is Pro or not. However, that field is currently set to false for everyone since no one is accepted. So, we rely on their registration to determine if they are an applicant or not and handle the deferred case.