### PR TITLE
Move Mentors header below Hamburger menu on mobile

### DIFF
--- a/app/mentors/styles.module.scss
+++ b/app/mentors/styles.module.scss
@@ -37,6 +37,10 @@
     justify-content: center;
     flex-flow: column nowrap;
     align-items: center;
+    // Moves the content below the hamburger menu on mobile devices
+    @media screen and (max-width: 700px) {
+        margin-top: 100px;
+    }
 }
 
 .body {

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -30,6 +30,10 @@ const DEFAULT_NAVBAR_ITEMS: NavbarItem[] = [
     //     title: "Map",
     //     link: "#"
     // },
+    {
+        title: "Mentors",
+        link: "/mentors"
+    }
 ];
 
 const Navbar = () => {
@@ -56,10 +60,6 @@ const Navbar = () => {
                             title: "Register",
                             link: "/register"
                         },
-                        {
-                            title: "Mentors",
-                            link: "/mentors"
-                        }
                     ]);
                 }
             });
@@ -70,10 +70,6 @@ const Navbar = () => {
                     title: "Register",
                     link: "/register"
                 },
-                {
-                    title: "Mentors",
-                    link: "/mentors"
-                }
             ]);
         }
     }, []);


### PR DESCRIPTION
Move Mentors header below Hamburger menu on mobile and always show the Mentor link in the navbar.

<img width="488" alt="Screenshot 2024-02-09 at 4 10 51 PM" src="https://github.com/HackIllinois/site/assets/21179174/940bfd46-a318-436a-968c-2cffbb382301">
