### PR TITLE
Redirect to hype site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    async redirects() {
+        return [
+            {
+                source: '/',
+                destination: 'https://hype.hackillinois.org',
+                permanent: false,
+            },
+        ];
+    }
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
https://hackillinois.org will now redirect to https://hype.hackillinois.org until the 2025 site is ready for deployment