### PR TITLE
Add local authentication

### DIFF
--- a/util/api.ts
+++ b/util/api.ts
@@ -42,16 +42,12 @@ export const isAuthenticated = (): string | null =>
     sessionStorage.getItem("token");
 
 export function authenticate(to: string): void {
-    if (process.env.NEXT_PUBLIC_REACT_APP_TOKEN) {
-        sessionStorage.setItem(
-            "token",
-            process.env.NEXT_PUBLIC_REACT_APP_TOKEN
-        );
-    } else {
-        localStorage.setItem("to", to);
-        to = `${APIv2}/auth/login/github/?device=web`;
-    }
-    window.location.replace(to);
+    localStorage.setItem("to", to);
+    const authUrl =
+        process.env.NODE_ENV == "development"
+            ? `${APIv2}/auth/login/github/?redirect=${window.location.origin}/auth/`
+            : `${APIv2}/auth/login/github/?device=web`;
+    window.location.replace(authUrl);
 }
 
 async function requestv2(method: MethodType, endpoint: string, body?: unknown) {


### PR DESCRIPTION
Uses the new `?redirect` parameter on `/auth/login/{device}` to redirect to a local auth endpoint when local, or use the website device when in prod.