### PR TITLE
add xs to multiselect checkboxes

### DIFF
--- a/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
+++ b/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
@@ -29,14 +29,43 @@
     }
 
     &:hover::before {
-        background-color: rgba(26, 188, 156, 0.5);
-    }
-
-    &.checked::before {
-        background-color: #1abc9c;
+        opacity: 0.5;
     }
 
     .checkbox {
         display: none;
     }
+}
+
+.checkboxSvg {
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    min-height: 28px;
+    margin-left: -52px;
+    pointer-events: none;
+    fill: none;
+    @media (max-width: 768px) {
+        width: 24px;
+        height: 24px;
+        min-width: 24px;
+        min-height: 24px;
+        margin-left: -48px;
+    }
+}
+
+.checkboxSvg path {
+    stroke: #ffffff;
+    stroke-width: 0;
+    fill: none;
+    transition: stroke-dashoffset 0.2s ease-in;
+}
+
+.checkboxSvg path + path {
+    transition: stroke-dashoffset 0.2s ease-out 0.2s;
+}
+
+.checkbox:checked ~ .checkboxSvg path {
+    stroke-dashoffset: 0;
+    stroke-width: 10px;
 }

--- a/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
+++ b/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
@@ -29,11 +29,16 @@
     }
 
     &:hover::before {
-        opacity: 0.5;
+        border: 2px solid #ad8e28;
     }
 
     .checkbox {
         display: none;
+    }
+
+    &:hover .checkboxSvg path {
+        stroke-dashoffset: 0;
+        stroke-width: 10px;
     }
 }
 
@@ -55,10 +60,12 @@
 }
 
 .checkboxSvg path {
-    stroke: #ffffff;
+    stroke: #ad8e28;
     stroke-width: 0;
     fill: none;
-    transition: stroke-dashoffset 0.2s ease-in;
+    transition:
+        stroke-dashoffset 0.2s ease-in-out,
+        stroke-width 0.2s ease-in-out;
 }
 
 .checkboxSvg path + path {

--- a/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
+++ b/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
@@ -30,15 +30,11 @@
 
     &:hover::before {
         border: 2px solid #ad8e28;
+        transition: border-color 0.2s ease-in-out;
     }
 
     .checkbox {
         display: none;
-    }
-
-    &:hover .checkboxSvg path {
-        stroke-dashoffset: 0;
-        stroke-width: 10px;
     }
 }
 

--- a/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
+++ b/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.module.scss
@@ -20,6 +20,7 @@
         height: 32px;
         border: 2px solid #ffffff;
         border-radius: 0.25em;
+        transition: border-color 0.2s ease-in-out;
         @media (max-width: 768px) {
             min-width: 28px;
             min-height: 28px;
@@ -30,7 +31,6 @@
 
     &:hover::before {
         border: 2px solid #ad8e28;
-        transition: border-color 0.2s ease-in-out;
     }
 
     .checkbox {

--- a/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.tsx
+++ b/components/Form/Checkboxes/StyledCheckbox/StyledCheckbox.tsx
@@ -23,23 +23,43 @@ const StyledCheckbox: React.FC<PropTypes> = ({
     style,
     ...props
 }) => (
-    <label
-        className={clsx(
-            styles.checkboxLabel,
-            checked && styles.checked,
-            className
-        )}
-        style={style}
-    >
-        <input
-            type="checkbox"
-            className={styles.checkbox}
-            value={value}
-            checked={checked}
-            {...props}
-        />
-        {label}
-    </label>
+    <div className={styles.checkboxWrapper}>
+        <label
+            className={clsx(
+                styles.checkboxLabel,
+                checked && styles.checked,
+                className
+            )}
+            style={style}
+        >
+            <input
+                type="checkbox"
+                className={styles.checkbox}
+                value={value}
+                checked={checked}
+                {...props}
+            />
+            <svg
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+                className={styles.checkboxSvg}
+            >
+                <path
+                    d="M 10 10 L 90 90"
+                    stroke="#000"
+                    strokeDasharray="113"
+                    strokeDashoffset={checked ? "0" : "113"}
+                />
+                <path
+                    d="M 90 10 L 10 90"
+                    stroke="#000"
+                    strokeDasharray="113"
+                    strokeDashoffset={checked ? "0" : "113"}
+                />
+            </svg>
+            {label}
+        </label>
+    </div>
 );
 
 export default StyledCheckbox;


### PR DESCRIPTION
- added "x" to checkbox when checked
- removed background-color within checkbox and on hover
- changed hover to reduce opacity instead of changing background-color

Unchecked:
<img width="436" alt="Screenshot 2024-12-29 at 12 13 07 AM" src="https://github.com/user-attachments/assets/2a492f20-8a1e-4fff-a659-10099fc188c9" />
Checked:
<img width="430" alt="Screenshot 2024-12-29 at 12 13 13 AM" src="https://github.com/user-attachments/assets/48a4e4bd-448f-47e3-8f73-e56097a1a138" />
On hover:
<img width="448" alt="Screenshot 2024-12-29 at 12 13 25 AM" src="https://github.com/user-attachments/assets/a0330d8c-0989-43e7-9f1f-a9203b233691" />
Checked and hovering:
<img width="448" alt="Screenshot 2024-12-29 at 12 13 32 AM" src="https://github.com/user-attachments/assets/4aa9e4e3-555f-4bf6-8045-dde6884c8bf2" />



