### PR TITLE
shine button goes to profile after registration closes

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -124,9 +124,13 @@ const faqDataWithoutLinks = [
         answer: (
             <p>
                 Yes! Cash prizes will be offered for winning teams in several
-                different categories, including HackOlympians . Additionally,
-                there are various mini-games and events that offer plenty of
-                opportunities to win prizes through our Point Shop!
+                different categories, including{" "}
+                <Link prefetch={false} href={"/olympians"}>
+                    HackOlympians
+                </Link>
+                . Additionally, there are various mini-games and events that
+                offer plenty of opportunities to win prizes through our Point
+                Shop!
             </p>
         )
     },
@@ -138,11 +142,14 @@ const faqDataWithoutLinks = [
         ),
         answer: (
             <p>
-                HackOlympians is an exclusive path tailored for prospective
-                attendees to dive into a competitively elevated hackathon
-                atmosphere for an increased prize value. It&apos;s a specialized
-                arena for experienced hackers who have mastered the fundamentals
-                and are now looking to test their skills in a more challenging
+                <Link prefetch={false} href={"/olympians"}>
+                    HackOlympians
+                </Link>{" "}
+                is an exclusive path tailored for prospective attendees to dive
+                into a competitively elevated hackathon atmosphere for an
+                increased prize value. It&apos;s a specialized arena for
+                experienced hackers who have mastered the fundamentals and are
+                now looking to test their skills in a more challenging
                 environment. Admission into HackOlympians requires completing
                 our application, which includes a coding challenge .
             </p>

--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -3,8 +3,9 @@ import React, { useEffect, useState } from "react";
 import styles from "./FAQ.module.scss";
 import Link from "next/link";
 import clsx from "clsx";
+import { getRegistrationStatus } from "@/util/api";
 
-const faqData = [
+const faqDataWithLinks = [
     {
         question: <strong>What is a Hackathon?</strong>,
         answer: (
@@ -106,9 +107,106 @@ const faqData = [
     }
 ];
 
+const faqDataWithoutLinks = [
+    {
+        question: <strong>What is a Hackathon?</strong>,
+        answer: (
+            <p>
+                A hackathon is a collaborative event where teams utilize their
+                skills to create projects that solve problems or identify new
+                opportunities! They typically run for a short and continuous
+                period of time. For Hacklllinois, meals will be provided.
+            </p>
+        )
+    },
+    {
+        question: <strong>Are there any prizes or incentives?</strong>,
+        answer: (
+            <p>
+                Yes! Cash prizes will be offered for winning teams in several
+                different categories, including HackOlympians . Additionally,
+                there are various mini-games and events that offer plenty of
+                opportunities to win prizes through our Point Shop!
+            </p>
+        )
+    },
+    {
+        question: (
+            <strong>
+                What is <i>HackOlympians</i>?
+            </strong>
+        ),
+        answer: (
+            <p>
+                HackOlympians is an exclusive path tailored for prospective
+                attendees to dive into a competitively elevated hackathon
+                atmosphere for an increased prize value. It&apos;s a specialized
+                arena for experienced hackers who have mastered the fundamentals
+                and are now looking to test their skills in a more challenging
+                environment. Admission into HackOlympians requires completing
+                our application, which includes a coding challenge .
+            </p>
+        )
+    },
+    {
+        question: (
+            <strong>What are the benefits of being a HackOlympian?</strong>
+        ),
+        answer: (
+            <p>
+                Attendees in this path have the exclusive opportunity to compete
+                for the grand Olympians prize. Additionally, they will gain
+                access to special networking opportunities with our event
+                sponsors and the chance to present their project in a thrilling
+                Shark-Tank inspired showcase, among other exciting perks - but
+                spots are limited, so register soon!
+            </p>
+        )
+    },
+    {
+        question: (
+            <strong>
+                How is HackOlympians different from standard HackIllinois
+                attendance?
+            </strong>
+        ),
+        answer: (
+            <>
+                <p>
+                    HackIllinois is a historically welcoming space for coders of
+                    all skill levels, particularly those who are just starting
+                    out. This inclusive environment encourages beginner-level
+                    coders to engage and learn, while HackOlympians caters to
+                    more advanced participants, fostering a competitive and
+                    stimulating atmosphere for seasoned hackers. All attendees
+                    from both paths will enjoy access to Hacklllinois&apos;s
+                    vibrant array of events, workshops, company Q&As, and the
+                    Company Expo. Each path will maintain the spirit of
+                    inclusivity and learning to ensure that all attendees,
+                    regardless of their track, experience the full magic of
+                    HackIllinois! Additionally, all HackIllinois attendees are
+                    eligible to compete in all our sponsored tracks.*
+                </p>
+                <br />
+                <p>
+                    *The Best Beginner and General prizes are reserved for
+                    HackIllinois General attendees, while the Best Olympians
+                    prize is reserved for HackOlympians attendees.
+                </p>
+            </>
+        )
+    }
+];
+
 const FAQ: React.FC = () => {
     const [currentPage, setCurrentPage] = useState(0);
     const [windowWidth, setWindowWidth] = useState(0);
+    const [registrationOpen, setRegistrationOpen] = useState(false);
+    useEffect(() => {
+        getRegistrationStatus().then(status => {
+            setRegistrationOpen(status.alive);
+        });
+    }, []);
 
     useEffect(() => {
         const handleResize = () => {
@@ -124,8 +222,8 @@ const FAQ: React.FC = () => {
         };
     });
 
-    const faqsPerPage = windowWidth < 1350 ? 3 : faqData.length;
-    const totalPages = Math.ceil(faqData.length / faqsPerPage);
+    const faqsPerPage = windowWidth < 1350 ? 3 : faqDataWithLinks.length;
+    const totalPages = Math.ceil(faqDataWithLinks.length / faqsPerPage);
     const showArrows = totalPages > 1;
 
     const navigatePage = (direction: number) => {
@@ -134,10 +232,15 @@ const FAQ: React.FC = () => {
         );
     };
 
-    const currentFAQs = faqData.slice(
-        currentPage * faqsPerPage,
-        (currentPage + 1) * faqsPerPage
-    );
+    const currentFAQs = registrationOpen
+        ? faqDataWithLinks.slice(
+              currentPage * faqsPerPage,
+              (currentPage + 1) * faqsPerPage
+          )
+        : faqDataWithoutLinks.slice(
+              currentPage * faqsPerPage,
+              (currentPage + 1) * faqsPerPage
+          );
 
     return (
         <div className={styles.faqContainer}>

--- a/components/Home/Olympian/Olympian.tsx
+++ b/components/Home/Olympian/Olympian.tsx
@@ -1,4 +1,7 @@
+"use client";
 import styles from "./Olympian.module.scss";
+import { useEffect, useState } from "react";
+import { getRegistrationStatus } from "@/util/api";
 
 import Image from "next/image";
 import LOGO from "@/public/home/olympian/logo.svg";
@@ -7,6 +10,12 @@ import OlympianButton from "@/components/OlympianButton/OlympianButton";
 import Description from "../Description/Description";
 
 const Olympian: React.FC = () => {
+    const [registrationOpen, setRegistrationOpen] = useState(true);
+    useEffect(() => {
+        getRegistrationStatus().then(status => {
+            setRegistrationOpen(status.alive);
+        });
+    }, []);
     return (
         <section className={styles.olympianMain}>
             <div className={styles.main}>
@@ -16,8 +25,8 @@ const Olympian: React.FC = () => {
                     className={styles.logo}
                 />
                 <OlympianButton
-                    text="Register Now"
-                    link="/register"
+                    text={registrationOpen ? "Register Now" : "Profile"}
+                    link={registrationOpen ? "/register" : "/profile"}
                     bottomPadding
                 />
             </div>

--- a/util/api.ts
+++ b/util/api.ts
@@ -4,7 +4,8 @@ import {
     WithId,
     RSVPType,
     ChallengeStatus,
-    FileType
+    FileType,
+    RegistrationStatus
 } from "./types";
 import { APIError } from "./error";
 import { handleError } from "./helpers";
@@ -156,5 +157,12 @@ export async function uploadFile(file: File, type: FileType): Promise<unknown> {
             type: "upload_error"
         });
     }
+    return res;
+}
+
+export async function getRegistrationStatus(): Promise<RegistrationStatus> {
+    const res = await requestv2("GET", "/registration/status").catch(body =>
+        handleError(body)
+    );
     return res;
 }

--- a/util/types.ts
+++ b/util/types.ts
@@ -251,6 +251,10 @@ export type RSVPDecisionType = {
 
 export type RegistrationRole = "attendee" | "mentor";
 
+export type RegistrationStatus = {
+    alive: boolean;
+};
+
 export type ChallengeStatus = {
     attempts: number;
     complete: boolean;


### PR DESCRIPTION
Landing page makes api call to check registration status. Button text is determined by boolean either showing "Register Now" or "Profile" and directs user accordingly.
<img width="405" alt="Screenshot 2025-01-22 at 8 36 00 PM" src="https://github.com/user-attachments/assets/fd53720d-7f20-4f5a-b01b-c8ab2553fcd5" />
