### PR TITLE
Change Olympian Button Size on Register Page

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -36,6 +36,7 @@ const Registration: React.FC = () => {
                         text="HackOlympian"
                         link="/register/challenge"
                         blue
+                        medium
                     />
                     <p className={styles.link}>
                         <Link
@@ -50,6 +51,7 @@ const Registration: React.FC = () => {
                         text="General Attendee"
                         link="/register/personal-info"
                         gold
+                        medium
                     />
                 </div>
                 <div className={styles.spacer}></div>

--- a/components/OlympianButton/OlympianButton.module.scss
+++ b/components/OlympianButton/OlympianButton.module.scss
@@ -146,7 +146,7 @@
             width: 45vw;
             height: 15vw;
             border-radius: 20px;
-            border-width: 1vw;
+            left: -1vw;
         }
     }
 }
@@ -173,10 +173,12 @@
     width: 22.5vw;
     height: 6vw;
     font-size: 2vw;
+    border-radius: 2vw;
 
     &::after {
         width: 22.5vw;
         height: 6vw;
+        border-radius: 2vw;
     }
 
     @media screen and (max-width: 960px) {
@@ -201,7 +203,7 @@
             width: 45vw;
             height: 15vw;
             border-radius: 20px;
-            border-width: 1vw;
+            left: -1vw;
         }
     }
 }

--- a/components/OlympianButton/OlympianButton.module.scss
+++ b/components/OlympianButton/OlympianButton.module.scss
@@ -106,25 +106,6 @@
     //         top: 16px;
     //     }
     // }
-    // @media screen and (max-width: 960px) {
-    // }
-    // @media screen and (max-width: 770px) {
-    //     width: 150px;
-    //     height: 45px;
-    //     font-size: 16px;
-    //     border-width: 4px;
-    //     border-radius: 20px;
-
-    //     &::after {
-    //         width: 150px;
-    //         height: 40px;
-
-    //         border-radius: 20px;
-
-    //         left: -4px;
-    //         top: 6px;
-    //     }
-    // }
 
     &:before {
         z-index: 1;
@@ -141,6 +122,32 @@
 
     &:hover:before {
         left: 65%;
+    }
+
+    @media screen and (max-width: 960px) {
+        width: 40vw;
+        height: 10vw;
+        font-size: 4vw;
+
+        &::after {
+            width: 40vw;
+            height: 10vw;
+        }
+    }
+
+    @media screen and (max-width: 468px) {
+        width: 45vw;
+        height: 15vw;
+        font-size: 4vw;
+        border-radius: 20px;
+        border-width: 1vw;
+
+        &::after {
+            width: 45vw;
+            height: 15vw;
+            border-radius: 20px;
+            border-width: 1vw;
+        }
     }
 }
 
@@ -159,5 +166,42 @@
     border-color: #aa8d36;
     &::after {
         background-color: #aa8d36;
+    }
+}
+
+.olympianButtonWrapper.medium .olympianButton {
+    width: 22.5vw;
+    height: 6vw;
+    font-size: 2vw;
+
+    &::after {
+        width: 22.5vw;
+        height: 6vw;
+    }
+
+    @media screen and (max-width: 960px) {
+        width: 30vw;
+        height: 10vw;
+        font-size: 3vw;
+
+        &::after {
+            width: 30vw;
+            height: 10vw;
+        }
+    }
+
+    @media screen and (max-width: 468px) {
+        width: 45vw;
+        height: 15vw;
+        font-size: 4vw;
+        border-radius: 20px;
+        border-width: 1vw;
+
+        &::after {
+            width: 45vw;
+            height: 15vw;
+            border-radius: 20px;
+            border-width: 1vw;
+        }
     }
 }

--- a/components/OlympianButton/OlympianButton.tsx
+++ b/components/OlympianButton/OlympianButton.tsx
@@ -9,6 +9,7 @@ interface OlympianButtonProps {
     bottomPadding?: boolean;
     blue?: boolean;
     gold?: boolean;
+    medium?: boolean;
 }
 
 const OlympianButton: React.FC<OlympianButtonProps> = ({
@@ -17,7 +18,8 @@ const OlympianButton: React.FC<OlympianButtonProps> = ({
     onClick,
     bottomPadding,
     blue,
-    gold
+    gold,
+    medium
 }) => {
     return (
         <div
@@ -25,7 +27,8 @@ const OlympianButton: React.FC<OlympianButtonProps> = ({
                 styles.olympianButtonWrapper,
                 bottomPadding && styles.bottomPadding,
                 blue && styles.blue,
-                gold && styles.gold
+                gold && styles.gold,
+                medium && styles.medium
             )}
         >
             {link ? (


### PR DESCRIPTION
- Added a "medium" property to the olympian button
- Used media queries to scale the buttons better and make them bigger on mobile screens

Smaller buttons on register page on desktop:
<img width="548" alt="Screenshot 2025-01-26 at 12 17 12 PM" src="https://github.com/user-attachments/assets/bb5e9bb6-0d96-496d-b716-c9529fc25915" />
Bigger buttons on mobile:
<img width="374" alt="Screenshot 2025-01-26 at 12 16 56 PM" src="https://github.com/user-attachments/assets/2464c20a-b705-4da9-8713-9f9914200209" />
