### PR TITLE
Prize Track Sponsor Icon Updates

### DIFF
--- a/app/prizes/page.tsx
+++ b/app/prizes/page.tsx
@@ -26,31 +26,31 @@ const prizesList = [
         title: "Best Financial Hack", // capital 1
         subheader: "(Track)",
         amount: "$1000",
-        imageSrc: HACK_LOGO.src
+        imageSrc: "/home/sponsors/capital_one.png"
     },
     {
         title: "Autonomous Vehicles", // john deere
         subheader: "(Track)",
         amount: "Raspberry Pi 4B and Vehicle Kit for each member",
-        imageSrc: HACK_LOGO.src
+        imageSrc: "/home/sponsors/john_deere.svg"
     },
     {
         title: "Best Developer Tool", // warp
         subheader: "(Track)",
         amount: "Keychron mechanical keyboard for each member",
-        imageSrc: HACK_LOGO.src
+        imageSrc: "/home/sponsors/warp.svg"
     },
     {
         title: "AI-Powered Agriculture Ops Planning", // agco
         subheader: "(Track)",
         amount: "$1000",
-        imageSrc: HACK_LOGO.src
+        imageSrc: "/home/sponsors/agco.svg"
     },
     {
         title: "Best Solana Blockchain Hack", // solana
         subheader: "(Track)",
         amount: "TBA",
-        imageSrc: HACK_LOGO.src
+        imageSrc: "/home/sponsors/solana.svg"
     }
 ];
 

--- a/components/Prize/Prize.module.scss
+++ b/components/Prize/Prize.module.scss
@@ -8,11 +8,13 @@
 .medalIcon {
     width: 100%;
     height: auto;
+    object-fit: contain;
 }
 
 .prizeIcon {
     height: 25%;
     z-index: 999;
+    width: 50%;
 }
 
 .medalOverlay1 {

--- a/components/Prize/Prize.module.scss
+++ b/components/Prize/Prize.module.scss
@@ -6,6 +6,7 @@
 }
 
 .medalIcon {
+    //
     width: 100%;
     height: auto;
     object-fit: contain;


### PR DESCRIPTION
Updated the Prize Track Sponsor Icons, as per comments in `prizes/page.tsx`. 

Desktop:
<img width="1376" alt="image" src="https://github.com/user-attachments/assets/aa5709f6-bb6d-470b-bb46-2fc3200f8d0e" />

Mobile:
<img width="636" alt="image" src="https://github.com/user-attachments/assets/2aa99423-9064-4cfd-87ca-cd5b2867e783" />

TODO: Ensure that the content stays within the prize icons (@BeckyBlake is currently working on this)
