### PR TITLE
Confirmation feedback and minor styling

### DIFF
--- a/app/register/general/formPages/Confirmation.tsx
+++ b/app/register/general/formPages/Confirmation.tsx
@@ -48,7 +48,7 @@ const Confirmation: React.FC = () => {
                     style={{
                         objectFit: "contain",
                         objectPosition: "top center",
-                        zIndex: -1
+                        zIndex: 0
                     }}
                 />
 
@@ -59,7 +59,8 @@ const Confirmation: React.FC = () => {
                         fontSize: { xs: "40px", sm: "60px", md: "80px" },
                         color: "white",
                         lineHeight: 1,
-                        mb: 0.5
+                        mb: 0.5,
+                        zIndex: 1
                     }}
                 >
                     APPLICATION
@@ -73,7 +74,8 @@ const Confirmation: React.FC = () => {
                         color: "white",
                         lineHeight: 1,
                         mb: 3,
-                        width: "100%"
+                        width: "100%",
+                        zIndex: 1
                     }}
                 >
                     FINISHED
@@ -84,7 +86,8 @@ const Confirmation: React.FC = () => {
                         fontFamily: `${montserrat.style.fontFamily}, sans-serif`,
                         fontWeight: 600,
                         fontSize: { xs: "11px", sm: "22px" },
-                        color: "white"
+                        color: "white",
+                        zIndex: 1
                     }}
                 >
                     Thank you for signing up for HackIllinois 2026!
@@ -96,26 +99,12 @@ const Confirmation: React.FC = () => {
                         fontWeight: 600,
                         fontSize: { xs: "11px", sm: "22px" },
                         color: "white",
-                        mb: "17px"
+                        mb: "17px",
+                        zIndex: 1
                     }}
                 >
                     Please check the status of your account in your email.
                 </Typography>
-
-                <Box
-                    sx={{
-                        position: "relative",
-                        width: { xs: "136px", sm: "189px" },
-                        height: { xs: "42px", sm: "59px" }
-                    }}
-                >
-                    <Image
-                        src="/registration/logo.svg"
-                        alt="White HackIllinois logo"
-                        fill
-                        style={{ objectFit: "contain" }}
-                    />
-                </Box>
             </Box>
         </Box>
     );

--- a/app/register/general/page.tsx
+++ b/app/register/general/page.tsx
@@ -292,7 +292,10 @@ const GeneralRegistration = () => {
                                     } // Personal info page has one arrow
                                     alignItems="center"
                                     gap={{ xs: "24px", md: "0px" }}
-                                    m={4}
+                                    mt={10}
+                                    mb={2}
+                                    mr={4}
+                                    ml={4}
                                 >
                                     {/* Left arrow */}
                                     {currentStep > 0 &&

--- a/components/Registration/Background.tsx
+++ b/components/Registration/Background.tsx
@@ -36,7 +36,7 @@ const Background = ({ step }: BackgroundProps) => {
                 width: "100vw",
                 height: "100vh",
                 overflow: "hidden",
-                zIndex: -1
+                zIndex: -100
             }}
         >
             <Image


### PR DESCRIPTION
- Remove Hack logo on confirmation page below the text
<img width="1056" height="720" alt="image" src="https://github.com/user-attachments/assets/3519a78c-1b62-4332-a755-5a913990c6ee" />



- Add larger margins around NavigationButtons
<img width="1879" height="512" alt="image" src="https://github.com/user-attachments/assets/36d9cdcf-f220-47a3-8f4a-8dd1b5dfb38c" />
