### PR TITLE
Make <html> element background black

### DIFF
--- a/app/globals.scss
+++ b/app/globals.scss
@@ -88,7 +88,7 @@ body {
 body {
     position: relative;
     color: rgb(255, 255, 255);
-    background-color: #5b619b;
+    background-color: #000000;
     overflow: clip;
     padding-right: 0 !important;
 }

--- a/app/legal/styles.module.scss
+++ b/app/legal/styles.module.scss
@@ -1,5 +1,5 @@
 .page {
-    background-color: #1a142b;
+    background-color: #000000;
     color: white;
     min-height: 100dvh;
     padding: 3rem;

--- a/app/register/general/page.tsx
+++ b/app/register/general/page.tsx
@@ -355,7 +355,7 @@ const GeneralRegistration = () => {
             </Snackbar>
             <Box
                 sx={{
-                    minHeight: "100vh", // Full viewport height
+                    minHeight: "100dvh", // Full viewport height
                     height: "100%",
                     width: "100%",
                     pb: "50px",


### PR DESCRIPTION
- Helps with "Y-overflow when using scroll selector", which is an issue inherent to Safari (https://stackoverflow.com/questions/56351216/ios-safari-unwanted-scroll-when-keyboard-is-opened-and-body-scroll-is-disabled)