### PR TITLE
character limits for registration questions

### DIFF
--- a/app/register/general/formPages/AppQuestions.tsx
+++ b/app/register/general/formPages/AppQuestions.tsx
@@ -59,6 +59,7 @@ const AppQuestions = ({ formik, accentColor }: AppQuestionsProps) => {
                         helperText={
                             !!touched.application1 ? errors.application1 : ""
                         }
+                        inputProps={{ maxLength: 700 }}
                     />
                 </Grid>
                 <Grid size={12}>
@@ -79,6 +80,7 @@ const AppQuestions = ({ formik, accentColor }: AppQuestionsProps) => {
                         helperText={
                             !!touched.application2 ? errors.application2 : ""
                         }
+                        inputProps={{ maxLength: 700 }}
                     />
                 </Grid>
                 <Grid size={12}>
@@ -99,6 +101,7 @@ const AppQuestions = ({ formik, accentColor }: AppQuestionsProps) => {
                         helperText={
                             !!touched.application3 ? errors.application3 : ""
                         }
+                        inputProps={{ maxLength: 1400 }}
                     />
                 </Grid>
 
@@ -122,6 +125,7 @@ const AppQuestions = ({ formik, accentColor }: AppQuestionsProps) => {
                                 ? errors.applicationOptional
                                 : ""
                         }
+                        inputProps={{ maxLength: 1400 }}
                     />
                 </Grid>
                 <Grid size={12}>

--- a/app/register/general/formPages/PersonalInfo.tsx
+++ b/app/register/general/formPages/PersonalInfo.tsx
@@ -37,6 +37,7 @@ const PersonalInfo = ({ formik, accentColor }: PersonalInfoProps) => {
                         onChange={handleChange}
                         error={!!touched.firstName && Boolean(errors.firstName)}
                         helperText={!!touched.firstName ? errors.firstName : ""}
+                        inputProps={{ maxLength: 200 }}
                     />
                 </Grid>
                 <Grid size={{ xs: 12, sm: 12, md: 4.75 }}>
@@ -49,6 +50,7 @@ const PersonalInfo = ({ formik, accentColor }: PersonalInfoProps) => {
                         onChange={handleChange}
                         error={!!touched.lastName && Boolean(errors.lastName)}
                         helperText={!!touched.lastName ? errors.lastName : ""}
+                        inputProps={{ maxLength: 200 }}
                     />
                 </Grid>
                 <Grid size={{ xs: 12, sm: 5, md: 2.5 }}>
@@ -82,6 +84,7 @@ const PersonalInfo = ({ formik, accentColor }: PersonalInfoProps) => {
                         helperText={
                             !!touched.preferredName ? errors.preferredName : ""
                         }
+                        inputProps={{ maxLength: 200 }}
                     />
                 </Grid>
 
@@ -96,6 +99,7 @@ const PersonalInfo = ({ formik, accentColor }: PersonalInfoProps) => {
                         onChange={handleChange}
                         error={!!touched.email && Boolean(errors.email)}
                         helperText={!!touched.email ? errors.email : ""}
+                        inputProps={{ maxLength: 200 }}
                     />
                 </Grid>
             </Grid>


### PR DESCRIPTION
-Added limits to text fields on registration pages (limits how much they can type)

On application questions page:
    - for 50 words, added 700 character limit
    - for 100 words, added 1400 character limit
on personal info page:
    - added 200 character limit for name & email fields (API has 200 character limit)


Note: Average word is 4.7 characters