### PR TITLE
Autosave for attending hack to review info transition

### DIFF
--- a/app/register/general/formPages/Review.tsx
+++ b/app/register/general/formPages/Review.tsx
@@ -9,7 +9,7 @@ import {
     Typography
 } from "@mui/material";
 import { FormikProps } from "formik";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
     AccordionHeader,
     AckErrorStyle,
@@ -40,19 +40,6 @@ const Review = ({ formik, onEditStep }: ReviewProps) => {
         (_event: React.SyntheticEvent, isExpanded: boolean) => {
             setExpanded(isExpanded ? panel : false);
         };
-
-    useEffect(() => {
-        if (!formik.dirty || formik.isSubmitting) return;
-
-        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-            e.preventDefault();
-            (e as any).returnValue = "";
-        };
-
-        window.addEventListener("beforeunload", handleBeforeUnload);
-        return () =>
-            window.removeEventListener("beforeunload", handleBeforeUnload);
-    }, [formik.dirty, formik.isSubmitting]);
 
     return (
         <>

--- a/app/register/general/page.tsx
+++ b/app/register/general/page.tsx
@@ -209,11 +209,9 @@ const GeneralRegistration = () => {
                 abortEarly: false
             });
         } catch {
-            console.log("Schema validation failed.");
             setShowClickOffAlert(true);
             return;
         }
-        console.log("Schema validation succeeded.");
 
         setShowClickOffAlert(false);
 
@@ -278,6 +276,7 @@ const GeneralRegistration = () => {
 
         if (currentStep === steps.length - 2) {
             if (isSaving) {
+                // This shouldn't happen. The submit button is disabled while saving.
                 return;
             }
             // Final step before submission
@@ -345,7 +344,7 @@ const GeneralRegistration = () => {
     }, [formik.values, registrationAuth.authenticated]);
 
     useEffect(() => {
-        // Don't autosave on the review info page and confirmation page.
+        // Don't autosave on the confirmation page.
         // This ensures that the user won't see an error when they submit.
         if (currentStep >= steps.length - 1) return;
         // we've just changed currentStep (section) -- autosave the values
@@ -362,10 +361,10 @@ const GeneralRegistration = () => {
         handleLoadDraft();
     }, [registrationAuth.authenticated]);
 
-    const handleBeforeUnload = useCallback((e: BeforeUnloadEvent) => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
         e.preventDefault();
         (e as any).returnValue = "";
-    }, []);
+    };
 
     useEffect(() => {
         if (!registrationAuth.authenticated) return;

--- a/app/register/general/page.tsx
+++ b/app/register/general/page.tsx
@@ -336,7 +336,7 @@ const GeneralRegistration = () => {
         // save modified values after a delay
         const timeout = setTimeout(() => {
             handleSave();
-        }, 1_000);
+        }, 10_000);
         saveTimeoutRef.current = timeout;
         return () => clearTimeout(timeout);
         // changing currentStep (i.e. changing section/subpage)

--- a/app/register/general/page.tsx
+++ b/app/register/general/page.tsx
@@ -209,9 +209,11 @@ const GeneralRegistration = () => {
                 abortEarly: false
             });
         } catch {
+            console.log("Schema validation failed.");
             setShowClickOffAlert(true);
             return;
         }
+        console.log("Schema validation succeeded.");
 
         setShowClickOffAlert(false);
 
@@ -275,6 +277,9 @@ const GeneralRegistration = () => {
         }
 
         if (currentStep === steps.length - 2) {
+            if (isSaving) {
+                return;
+            }
             // Final step before submission
             setShowClickOffAlert(false);
             setIsLoadingComponent(true);
@@ -324,7 +329,7 @@ const GeneralRegistration = () => {
     };
 
     useEffect(() => {
-        if (currentStep >= steps.length - 2) {
+        if (currentStep >= steps.length - 1) {
             setShowClickOffAlert(false);
             return;
         }
@@ -332,7 +337,7 @@ const GeneralRegistration = () => {
         // save modified values after a delay
         const timeout = setTimeout(() => {
             handleSave();
-        }, 10_000);
+        }, 1_000);
         saveTimeoutRef.current = timeout;
         return () => clearTimeout(timeout);
         // changing currentStep (i.e. changing section/subpage)
@@ -342,7 +347,7 @@ const GeneralRegistration = () => {
     useEffect(() => {
         // Don't autosave on the review info page and confirmation page.
         // This ensures that the user won't see an error when they submit.
-        if (currentStep >= steps.length - 2) return;
+        if (currentStep >= steps.length - 1) return;
         // we've just changed currentStep (section) -- autosave the values
         // immediately, then clear the 10-second-delay autosave so the user
         // doesn't see the popup twice
@@ -357,10 +362,11 @@ const GeneralRegistration = () => {
         handleLoadDraft();
     }, [registrationAuth.authenticated]);
 
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    const handleBeforeUnload = useCallback((e: BeforeUnloadEvent) => {
         e.preventDefault();
         (e as any).returnValue = "";
-    };
+    }, []);
+
     useEffect(() => {
         if (!registrationAuth.authenticated) return;
         if (!showClickOffAlert) {
@@ -527,6 +533,7 @@ const GeneralRegistration = () => {
                                 pointRight={true}
                                 isMobile={isMobile}
                                 onClick={() => handleNextOrSubmit()}
+                                disabled={isSaving}
                                 type="button"
                             />
                         )}

--- a/util/validation.ts
+++ b/util/validation.ts
@@ -166,12 +166,9 @@ export const draftValidationSchemas = [
 
     // 4. Review (final acknowledgements)
     Yup.object({
-        reviewedAcknowledge: Yup.boolean()
-            .required("Please confirm you have reviewed your information")
-            .oneOf([true], "Please confirm you have reviewed your information"),
-        codeOfConductAcknowledge: Yup.boolean()
-            .required("You must accept the Code of Conduct")
-            .oneOf([true], "You must accept the Code of Conduct")
+        reviewedAcknowledge: Yup.boolean(),
+        codeOfConductAcknowledge: Yup.boolean(),
+        mlhDataSharingAcknowledge: Yup.boolean()
     }),
 
     // 5. Confirmation (no new inputs, keep for indexing purposes)


### PR DESCRIPTION
Transitions from "Attending Hack" to "Review Info" did not automatically save information on the Attending Hack page. This PR resolves this issue by enabling autosaves on the Review Info page.